### PR TITLE
공개된 일기 목록을 최신순으로 조회 API 구현

### DIFF
--- a/src/main/java/com/travel/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/travel/domain/diary/controller/DiaryController.java
@@ -2,6 +2,7 @@ package com.travel.domain.diary.controller;
 
 import com.travel.domain.diary.dto.request.CreateDiaryRequest;
 import com.travel.domain.diary.dto.response.DiaryDetailDto;
+import com.travel.domain.diary.dto.response.DiaryListDto;
 import com.travel.domain.diary.dto.response.DiaryResponse;
 import com.travel.domain.diary.service.DiaryService;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 
 @RestController
@@ -26,9 +29,16 @@ public class DiaryController {
         DiaryResponse response = diaryService.createDiary(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
+
     @GetMapping("/{id}")
     public ResponseEntity<DiaryDetailDto> getDiary(@PathVariable Long id) {
         DiaryDetailDto response = diaryService.getDiaryById(id);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<List<DiaryListDto>> diaryList() {
+        List<DiaryListDto> response = diaryService.getDiaryListByPublic();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/travel/domain/diary/dto/response/DiaryListDto.java
+++ b/src/main/java/com/travel/domain/diary/dto/response/DiaryListDto.java
@@ -1,0 +1,28 @@
+package com.travel.domain.diary.dto.response;
+
+import com.travel.domain.diary.model.Diary;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public class DiaryListDto {
+
+    private Long id;              // 다이어리 식별자
+    private String title;         // 제목
+    private String imgUrl;        // 대표 이미지
+    private LocalDate travelDate; // 여행 날짜
+    private String location;      // 여행지
+    private String weather;       // 날씨 (선택사항)
+
+    public static DiaryListDto from(Diary diary) {
+        return DiaryListDto.builder()
+                .id(diary.getId())
+                .title(diary.getTitle())
+                .imgUrl(diary.getImageUrl())
+                .travelDate(diary.getTravelDate())
+                .location(diary.getLocation())
+                .weather(diary.getWeather()) // 필요 시 포함
+                .build();
+    }
+}

--- a/src/main/java/com/travel/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/travel/domain/diary/repository/DiaryRepository.java
@@ -1,9 +1,13 @@
 package com.travel.domain.diary.repository;
 
 import com.travel.domain.diary.model.Diary;
+import com.travel.domain.diary.model.Visibility;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
+    List<Diary> findAllByVisibilityOrderByCreatedAtDesc(Visibility visibility);
 }

--- a/src/main/java/com/travel/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/travel/domain/diary/service/DiaryService.java
@@ -4,9 +4,11 @@ import com.travel.domain.diary.dto.request.AiDiaryRequest;
 import com.travel.domain.diary.dto.request.CreateDiaryRequest;
 import com.travel.domain.diary.dto.response.AiDiaryResponse;
 import com.travel.domain.diary.dto.response.DiaryDetailDto;
+import com.travel.domain.diary.dto.response.DiaryListDto;
 import com.travel.domain.diary.dto.response.DiaryResponse;
 import com.travel.domain.diary.model.Diary;
 import com.travel.domain.diary.model.Emotion;
+import com.travel.domain.diary.model.Visibility;
 import com.travel.domain.diary.repository.DiaryRepository;
 import com.travel.domain.diary.util.DiaryMapper;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -55,5 +58,13 @@ public class DiaryService {
                 .orElseThrow(() -> new RuntimeException("해당 일기를 찾을 수 없습니다."));
 
         return DiaryMapper.toDiaryDetailDto(diary);
+    }
+
+    public List<DiaryListDto> getDiaryListByPublic() {
+        // 최신순으로 정렬
+        List<Diary> diaries = diaryRepository.findAllByVisibilityOrderByCreatedAtDesc(Visibility.PUBLIC);
+        return diaries.stream()
+                .map(DiaryListDto::from)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 공개된 다이어리 목록을 조회할 수 있는 엔드포인트가 추가되었습니다.
  * 다이어리 목록은 대표 이미지, 제목, 여행 날짜, 위치, 날씨 등의 요약 정보와 함께 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->